### PR TITLE
Add support for event sources.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-lazylog",
-  "version": "4.5.2",
+  "version": "4.5.3",
   "description": "React Lazy Logviewer",
   "license": "MPL-2.0",
   "repository": "mozilla-frontend-infra/react-lazylog",

--- a/src/emitter.js
+++ b/src/emitter.js
@@ -1,0 +1,42 @@
+import mitt from 'mitt';
+import { List } from 'immutable';
+import { encode } from './encoding';
+import { bufferConcat, convertBufferToLines } from './utils';
+
+export default eventSource => {
+  const emitter = mitt();
+  let overage = null;
+  let encodedLog = new Uint8Array();
+
+  eventSource.on('data', data => {
+    encodedLog = bufferConcat(encodedLog, encode(data));
+
+    const { lines, remaining } = convertBufferToLines(encode(data), overage);
+
+    overage = remaining;
+
+    emitter.emit('update', { lines, encodedLog });
+  });
+
+  eventSource.on('done', () => {
+    if (overage) {
+      emitter.emit('update', { lines: List.of(overage), encodedLog });
+    }
+
+    emitter.emit('end', encodedLog);
+  });
+
+  emitter.on('start', async () => {
+    try {
+      eventSource.emit('start');
+    } catch (err) {
+      emitter.emit('error', err);
+    }
+  });
+
+  emitter.on('abort', () => {
+    eventSource.emit('abort');
+  });
+
+  return emitter;
+};


### PR DESCRIPTION
This adds support for retrieving logs from an event emitter that
produces text in the 'data' event.

This enables displaying logs from other sources besides urls, or
websockets.

For example:

- Log data from a WebRTC datachannel.
- Log results from a gRPC call.